### PR TITLE
New jn changes

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -185,7 +185,7 @@ doorkeeper.
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
-
+    option :refresh_token_revoke_in,        default: 0
     attr_reader :reuse_access_token
 
     def refresh_token_enabled?

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -11,11 +11,15 @@ module Doorkeeper
 
       def revoke_previous_refresh_token!
         return unless refresh_token_revoked_on_use?
-        old_refresh_token.revoke if old_refresh_token
+        old_refresh_token.revoke_in(Doorkeeper.configuration.refresh_token_revoke_in) if old_refresh_token
         update_attribute :previous_refresh_token, ""
       end
 
       private
+
+      def revoke_in(time)
+        update_attribute :revoked_at, Time.now.utc + time
+      end
 
       def old_refresh_token
         @old_refresh_token ||=

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -15,11 +15,11 @@ module Doorkeeper
         update_attribute :previous_refresh_token, ""
       end
 
-      private
-
       def revoke_in(time)
         update_attribute :revoked_at, Time.now.utc + time
       end
+
+      private
 
       def old_refresh_token
         @old_refresh_token ||=


### PR DESCRIPTION
A, R exist and A expired
Changes:
R generates A1, R1 first time
R generates A2, R1 second time
.
.
R generates An, R1 nth time

Use of any A1 to An revokes R on use in refresh_token_revoke_in seconds
Client should use R1 to generate further tokens